### PR TITLE
feat(config): Add configuration for adding javascript version.

### DIFF
--- a/lib/middleware/karma.js
+++ b/lib/middleware/karma.js
@@ -14,6 +14,7 @@
 var path = require('path')
 var util = require('util')
 var url = require('url')
+var useragent = require('useragent')
 
 var urlparse = function (urlStr) {
   var urlObj = url.parse(urlStr, true)
@@ -59,9 +60,21 @@ var getXUACompatibleUrl = function (url) {
   return value
 }
 
+var isFirefox = function (req) {
+  if (!(req && req.headers)) {
+    return false
+  }
+
+  // Browser check
+  var firefox = useragent.is(req.headers['user-agent']).firefox
+
+  return firefox
+}
+
 var createKarmaMiddleware = function (filesPromise, serveStaticFile, serveFile,
   /* config.basePath */ basePath, /* config.urlRoot */ urlRoot, /* config.client */ client,
-  /* config.customContextFile */ customContextFile, /* config.customDebugFile */ customDebugFile) {
+  /* config.customContextFile */ customContextFile, /* config.customDebugFile */ customDebugFile,
+  /* config.jsVersion */ jsVersion) {
   return function (request, response, next) {
     var requestUrl = request.normalizedUrl.replace(/\?.*/, '')
 
@@ -144,7 +157,15 @@ var createKarmaMiddleware = function (filesPromise, serveStaticFile, serveFile,
               return util.format(LINK_TAG_HTML, filePath)
             }
 
-            return util.format(SCRIPT_TAG, SCRIPT_TYPE[fileExt] || 'text/javascript', filePath)
+            // The script tag to be placed
+            var scriptType = (SCRIPT_TYPE[fileExt] || 'text/javascript')
+
+            // In case there is a JavaScript version specified and this is a Firefox browser
+            if (jsVersion && isFirefox(request)) {
+              scriptType += ';version=' + jsVersion
+            }
+
+            return util.format(SCRIPT_TAG, scriptType, filePath)
           })
 
           // TODO(vojta): don't compute if it's not in the template
@@ -199,7 +220,7 @@ var createKarmaMiddleware = function (filesPromise, serveStaticFile, serveFile,
 
 createKarmaMiddleware.$inject = ['filesPromise', 'serveStaticFile', 'serveFile',
   'config.basePath', 'config.urlRoot', 'config.client', 'config.customContextFile',
-  'config.customDebugFile']
+  'config.customDebugFile', 'config.jsVersion']
 
 // PUBLIC API
 exports.create = createKarmaMiddleware

--- a/test/e2e/support/tag/tag.js
+++ b/test/e2e/support/tag/tag.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-unused-vars */
+var isFirefox = function () {
+  return typeof InstallTrigger !== 'undefined'
+}
+
+var containsJsTag = function () {
+  var scripts = document.getElementsByTagName('script')
+  for (var i = 0; i < scripts.length; i++) {
+    if (scripts[i].type.indexOf(';version=') > -1) {
+      return true
+    }
+  }
+  return false
+}

--- a/test/e2e/support/tag/test.js
+++ b/test/e2e/support/tag/test.js
@@ -1,0 +1,6 @@
+/* globals containsJsTag, isFirefox */
+describe('JavaScript version tag', function () {
+  it('should add the version tag, if Firefox is used', function () {
+    expect(containsJsTag()).toBe(isFirefox())
+  })
+})

--- a/test/e2e/tag.feature
+++ b/test/e2e/tag.feature
@@ -1,0 +1,41 @@
+Feature: JavaScript Tag
+  In order to use Karma
+  As a person who wants to write great tests
+  I want to be able to run tests from the command line.
+
+  Scenario: Execute a test in Firefox with version, with JavaScript tag
+    Given a configuration with:
+      """
+      files = ['tag/tag.js', 'tag/test.js'];
+      browsers = ['Firefox']
+      jsVersion = 1.8
+      plugins = [
+        'karma-jasmine',
+        'karma-firefox-launcher'
+      ]
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      Firefox
+      """
+
+  Scenario: Execute a test in Chrome with version, without JavaScript tag
+    Given a configuration with:
+      """
+      files = ['tag/tag.js', 'tag/test.js'];
+      browsers = ['Chrome'];
+      jsVersion = 1.8;
+      plugins = [
+        'karma-jasmine',
+        'karma-chrome-launcher'
+      ];
+      """
+    When I start Karma
+    Then it passes with:
+      """
+      .
+      Chrome
+      """
+      


### PR DESCRIPTION
Add the configuration to add a javascript version tag to the loaded scripts. Only applied when the Firefox browser is run.

Closes #1719
